### PR TITLE
fix: copy url button position in blog pages

### DIFF
--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -19,7 +19,7 @@ function CopyButton() {
         setText('Copied')
         navigator.clipboard.writeText(currentUrl)
       }}
-      className="font-base flex items-center gap-1 text-center text-sm text-zinc-500 transition-colors dark:text-zinc-400"
+      className="font-base flex cursor-pointer items-center gap-1 text-center text-sm text-zinc-500 transition-colors dark:text-zinc-400"
       type="button"
     >
       <TextMorph>{text}</TextMorph>
@@ -43,10 +43,10 @@ export default function LayoutBlogPost({
         }}
       />
 
-      <div className="absolute top-24 right-4">
-        <CopyButton />
-      </div>
       <main className="prose prose-gray prose-h4:prose-base dark:prose-invert prose-h1:text-xl prose-h1:font-medium prose-h2:mt-12 prose-h2:scroll-m-20 prose-h2:text-lg prose-h2:font-medium prose-h3:text-base prose-h3:font-medium prose-h4:font-medium prose-h5:text-base prose-h5:font-medium prose-h6:text-base prose-h6:font-medium prose-strong:font-medium mt-24 pb-20">
+        <div className="absolute top-38 left-4">
+          <CopyButton />
+        </div>
         {children}
       </main>
     </>


### PR DESCRIPTION
### 📝 Pull Request Summary

It fixes Copy URL button position in blog pages.

---

### 📋 Changes

- Moved Copy URL button from top right to top left

---

### 🔍 Related Issue(s)

Fixes #8

---


### 📷 Screenshots (if applicable)

<img width="742" height="477" alt="image" src="https://github.com/user-attachments/assets/d2a093dc-eac3-479a-b9ab-23beea218946" />

---

### ✅ Checklist

Please ensure the following before requesting a review:

- [x] My code follows the project's coding standards
- [x] I’ve added necessary documentation (if applicable)
- [x] I’ve tested my changes and verified functionality
- [x] I’ve linked related issues (if any)
- [x] This PR is ready for review

---

### 🙌 Additional Notes

N/A
