### PR TITLE
fix deprecated images.domains in nextjs config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,7 +5,13 @@ const nextConfig = {
   reactStrictMode: true,
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
   images: {
-    domains: ['brennanholmes.vercel.app'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'brennanholmes.vercel.app',
+        pathname: '/**',
+      },
+    ],
   },
 }
 


### PR DESCRIPTION
## Before

<img width="626" height="466" alt="image" src="https://github.com/user-attachments/assets/67c0d804-0956-49e2-b39d-669909249800" />

## After

```mjs
const nextConfig = {
  reactStrictMode: true,
  pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
  images: {
    remotePatterns: [
      {
        protocol: 'https',
        hostname: 'brennanholmes.vercel.app',
        pathname: '/**',
      },
    ],
  },
}
```